### PR TITLE
Implementing new import/export feature

### DIFF
--- a/PROBLEM WITH HIVE CURRENTLY.txt
+++ b/PROBLEM WITH HIVE CURRENTLY.txt
@@ -1,1 +1,0 @@
-The problem is that the hashmap here uses Configuratiuon, Behaviour pairs. These simply do not exist for Hive.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hive_flutter/adapters.dart';
-import 'package:logger/logger.dart';
 import 'package:turing_machines/models/Actions.dart';
 import 'package:turing_machines/models/Behaviour.dart';
 import 'package:turing_machines/models/Configuration.dart';
@@ -39,8 +38,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    //Helpful for debugging/testing.
-    Logger().i(target.name);
+
     return MaterialApp(
       title: 'Turing Machine Generator',
       debugShowCheckedModeBanner: false,

--- a/lib/models/Actions.dart
+++ b/lib/models/Actions.dart
@@ -2,11 +2,12 @@
 
 import 'package:hive_flutter/adapters.dart';
 import 'package:turing_machines/exceptions/action_exceptions.dart';
-
+import 'package:json_annotation/json_annotation.dart';
 //Represents an Action which can be performed on the tape of a turing machine.
 part 'Actions.g.dart';
 
 @HiveType(typeId: 4)
+@JsonSerializable()
 class Actions {
   @HiveField(0)
   String symbol;
@@ -63,6 +64,14 @@ class Actions {
 
   @override
   int get hashCode => symbol.hashCode ^ type.hashCode;
+
+  // Connect the generated function to the `fromJson`
+  // factory.
+  factory Actions.fromJson(Map<String, dynamic> json) =>
+      _$ActionsFromJson(json);
+
+  // Connect the generated  function to the `toJson` method.
+  Map<String, dynamic> toJson() => _$ActionsToJson(this);
 }
 
 @HiveType(typeId: 5)

--- a/lib/models/Actions.g.dart
+++ b/lib/models/Actions.g.dart
@@ -96,3 +96,25 @@ class ActionTypeAdapter extends TypeAdapter<ActionType> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Actions _$ActionsFromJson(Map<String, dynamic> json) => Actions(
+      type: $enumDecode(_$ActionTypeEnumMap, json['type']),
+      symbol: json['symbol'] as String? ?? "",
+    );
+
+Map<String, dynamic> _$ActionsToJson(Actions instance) => <String, dynamic>{
+      'symbol': instance.symbol,
+      'type': _$ActionTypeEnumMap[instance.type]!,
+    };
+
+const _$ActionTypeEnumMap = {
+  ActionType.P: 'P',
+  ActionType.R: 'R',
+  ActionType.L: 'L',
+  ActionType.E: 'E',
+  ActionType.NONE: 'NONE',
+};

--- a/lib/models/Behaviour.dart
+++ b/lib/models/Behaviour.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/adapters.dart';
 import 'package:turing_machines/models/Actions.dart';
+import 'package:json_annotation/json_annotation.dart';
 part 'Behaviour.g.dart';
 
 @HiveType(typeId: 3)
+@JsonSerializable()
 class Behaviour {
   const Behaviour({required this.actions, required this.f_config});
   @HiveField(0)
@@ -21,4 +23,12 @@ class Behaviour {
 
   @override
   int get hashCode => actions.hashCode ^ f_config.hashCode;
+
+  // Connect the generated function to the `fromJson`
+  // factory.
+  factory Behaviour.fromJson(Map<String, dynamic> json) =>
+      _$BehaviourFromJson(json);
+
+  // Connect the generated  function to the `toJson` method.
+  Map<String, dynamic> toJson() => _$BehaviourToJson(this);
 }

--- a/lib/models/Behaviour.g.dart
+++ b/lib/models/Behaviour.g.dart
@@ -42,3 +42,19 @@ class BehaviourAdapter extends TypeAdapter<Behaviour> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Behaviour _$BehaviourFromJson(Map<String, dynamic> json) => Behaviour(
+      actions: (json['actions'] as List<dynamic>)
+          .map((e) => Actions.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      f_config: json['f_config'] as String,
+    );
+
+Map<String, dynamic> _$BehaviourToJson(Behaviour instance) => <String, dynamic>{
+      'actions': instance.actions,
+      'f_config': instance.f_config,
+    };

--- a/lib/models/Configuration.dart
+++ b/lib/models/Configuration.dart
@@ -1,8 +1,9 @@
 import 'package:hive_flutter/adapters.dart';
-
+import 'package:json_annotation/json_annotation.dart';
 part 'Configuration.g.dart';
 
 @HiveType(typeId: 2)
+@JsonSerializable()
 class Configuration {
   const Configuration({required this.m_config, required this.symbol});
   //Build a Configuration object by parsing a given String containing the
@@ -38,6 +39,14 @@ class Configuration {
   String toString() {
     return "$m_config, ${parseSymbolOutput(symbol)}";
   }
+
+  // Connect the generated function to the `fromJson`
+  // factory.
+  factory Configuration.fromJson(Map<String, dynamic> json) =>
+      _$ConfigurationFromJson(json);
+
+  // Connect the generated  function to the `toJson` method.
+  Map<String, dynamic> toJson() => _$ConfigurationToJson(this);
 }
 
 //Parse symbol output,convert "" to "NONE" else no change

--- a/lib/models/Configuration.g.dart
+++ b/lib/models/Configuration.g.dart
@@ -42,3 +42,19 @@ class ConfigurationAdapter extends TypeAdapter<Configuration> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Configuration _$ConfigurationFromJson(Map<String, dynamic> json) =>
+    Configuration(
+      m_config: json['m_config'] as String,
+      symbol: json['symbol'] as String,
+    );
+
+Map<String, dynamic> _$ConfigurationToJson(Configuration instance) =>
+    <String, dynamic>{
+      'm_config': instance.m_config,
+      'symbol': instance.symbol,
+    };

--- a/lib/models/Tape.dart
+++ b/lib/models/Tape.dart
@@ -1,4 +1,3 @@
-import 'package:logger/logger.dart';
 import 'package:turing_machines/exceptions/action_exceptions.dart';
 import 'package:turing_machines/models/Actions.dart';
 
@@ -61,8 +60,7 @@ class Tape {
       }
       s += symbol + " ";
     }
-    Logger().i("Cursor at $pointer");
-    Logger().i(s);
+    print(s);
   }
 
   //default tape for a turing machine at iteration 0

--- a/lib/models/TuringMachineModel.dart
+++ b/lib/models/TuringMachineModel.dart
@@ -4,9 +4,11 @@ import 'package:turing_machines/models/Behaviour.dart';
 import 'package:turing_machines/models/Configuration.dart';
 import 'package:turing_machines/models/Tape.dart';
 import 'package:turing_machines/models/TuringMachines.dart';
+import 'package:json_annotation/json_annotation.dart';
 part "TuringMachineModel.g.dart";
 
 @HiveType(typeId: 0)
+@JsonSerializable()
 class TuringMachineModel {
   @HiveField(0)
   String initial_config;
@@ -43,4 +45,12 @@ class TuringMachineModel {
 
     return machine;
   }
+
+  // Connect the generated function to the `fromJson`
+  // factory.
+  factory TuringMachineModel.fromJson(Map<String, dynamic> json) =>
+      _$TuringMachineModelFromJson(json);
+
+  // Connect the generated  function to the `toJson` method.
+  Map<String, dynamic> toJson() => _$TuringMachineModelToJson(this);
 }

--- a/lib/models/TuringMachineModel.dart
+++ b/lib/models/TuringMachineModel.dart
@@ -1,5 +1,5 @@
 import 'package:hive_flutter/adapters.dart';
-import 'package:logger/logger.dart';
+
 import 'package:turing_machines/models/Behaviour.dart';
 import 'package:turing_machines/models/Configuration.dart';
 import 'package:turing_machines/models/Tape.dart';
@@ -40,8 +40,6 @@ class TuringMachineModel {
     );
     machine.current_config = initial_config;
     machine.iterations = 0;
-    Logger().i(
-        "Current config of machine read from memory: ${machine.current_config}");
 
     return machine;
   }

--- a/lib/models/TuringMachineModel.g.dart
+++ b/lib/models/TuringMachineModel.g.dart
@@ -45,3 +45,25 @@ class TuringMachineModelAdapter extends TypeAdapter<TuringMachineModel> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TuringMachineModel _$TuringMachineModelFromJson(Map<String, dynamic> json) =>
+    TuringMachineModel(
+      initial_config: json['initial_config'] as String,
+      configs: (json['configs'] as List<dynamic>)
+          .map((e) => Configuration.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      behaviours: (json['behaviours'] as List<dynamic>)
+          .map((e) => Behaviour.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$TuringMachineModelToJson(TuringMachineModel instance) =>
+    <String, dynamic>{
+      'initial_config': instance.initial_config,
+      'configs': instance.configs,
+      'behaviours': instance.behaviours,
+    };

--- a/lib/screens/LoadMachineScreen.dart
+++ b/lib/screens/LoadMachineScreen.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:hive_flutter/adapters.dart';
 import 'package:turing_machines/main.dart';
 import 'package:turing_machines/models/Targets.dart';
 import 'package:turing_machines/models/TuringMachineModel.dart';
+import 'package:turing_machines/models/TuringMachines.dart';
 import 'package:turing_machines/screens/TableScreen.dart';
 
 class LoadMachineScreen extends StatefulWidget {
@@ -26,6 +29,13 @@ class _LoadMachineScreenState extends State<LoadMachineScreen> {
         appBar: AppBar(
           title: const Text("Load a saved machine"),
           actions: [
+            IconButton(
+              onPressed: () {
+                _showJsonInput(context);
+              },
+              icon: const Icon(Icons.import_export_outlined),
+            ),
+            const Gap(5),
             IconButton(
                 onPressed: () async {
                   await machineBox.clear();
@@ -139,5 +149,88 @@ class _LoadMachineScreenState extends State<LoadMachineScreen> {
         },
       ),
     );
+  }
+
+  //move to table screen with the machine represented by the json string.
+  void actuateJsonMachine(String json) {
+    // ignore: non_constant_identifier_names
+    TuringMachine target_machine =
+        TuringMachineModel.fromJson(jsonDecode(json)).actuateMachine();
+    Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) {
+      return TableScreen(machine: target_machine);
+    }));
+  }
+
+  //show input sheet for Json string
+  void _showJsonInput(BuildContext context) {
+    TextEditingController tc = TextEditingController();
+    showModalBottomSheet(
+        useSafeArea: true,
+        isScrollControlled: true,
+        context: context,
+        isDismissible: false,
+        enableDrag: false,
+        builder: (context) {
+          return Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
+            ),
+            child: Container(
+              height: 300,
+              padding: const EdgeInsets.only(
+                  bottom: 8.0, top: 15, left: 15, right: 15),
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text(
+                        "Enter the export string to construct the turing machine: "),
+                    const Gap(15),
+                    TextField(
+                      controller: tc,
+                      maxLines: 5,
+                    ),
+                    const Gap(15),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 5.0),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          ElevatedButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            child: const Text("Cancel"),
+                          ),
+                          const Gap(7.0),
+                          ElevatedButton(
+                            onPressed: () {
+                              //Code to actuate and navigate to machine
+                              try {
+                                Navigator.pop(context);
+                                actuateJsonMachine(tc.text);
+                                // ignore: unused_catch_clause
+                              } on FormatException catch (e) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Invalid String format!'),
+                                    backgroundColor: Colors.red,
+                                  ),
+                                );
+                              }
+                            },
+                            child: const Text("Load machine"),
+                          )
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        });
   }
 }

--- a/lib/screens/TableScreen.dart
+++ b/lib/screens/TableScreen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 
 import 'package:gap/gap.dart';
 import 'package:hive/hive.dart';
-import 'package:logger/logger.dart';
 import 'package:turing_machines/main.dart';
 import 'package:turing_machines/models/Behaviour.dart';
 import 'package:turing_machines/models/Configuration.dart';
@@ -85,7 +84,7 @@ class _TableScreenState extends State<TableScreen> {
     if (widget.machine.initial_config.isNotEmpty) {
       initialConfigValue = widget.machine.initial_config;
     }
-    Logger().w("The initial Config is: $initialConfigValue");
+
     _input.text = widget.machine.tape.toString();
   }
 
@@ -678,7 +677,7 @@ class _TableScreenState extends State<TableScreen> {
     TextEditingController controller = TextEditingController(
         text: jsonEncode(
             TuringMachineModel.fromMachine(machine: widget.machine).toJson()));
-    Logger().w("The Json string is: ${controller.text}");
+
     showModalBottomSheet(
         useSafeArea: true,
         isScrollControlled: true,

--- a/lib/screens/TableScreen.dart
+++ b/lib/screens/TableScreen.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: unused_catch_clause
 
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import 'package:gap/gap.dart';
@@ -104,6 +106,13 @@ class _TableScreenState extends State<TableScreen> {
                   _showInputSheet(context);
                 },
                 icon: const Icon(Icons.save_as_outlined)),
+            const Gap(5),
+            IconButton(
+              onPressed: () {
+                _showJsonSheet();
+              },
+              icon: const Icon(Icons.share_outlined),
+            ),
             const Gap(5),
             IconButton(
                 onPressed: () {
@@ -643,8 +652,8 @@ class _TableScreenState extends State<TableScreen> {
                           ElevatedButton(
                             onPressed: () {
                               //saving code here
-                              widget.machine.tape =
-                                  widget.machine.tape.cloneTape();
+                              // widget.machine.tape =
+                              //     widget.machine.tape.cloneTape();
                               _machinesBox.put(
                                   _saveName.text,
                                   TuringMachineModel.fromMachine(
@@ -656,6 +665,48 @@ class _TableScreenState extends State<TableScreen> {
                           )
                         ],
                       ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        });
+  }
+
+  void _showJsonSheet() {
+    TextEditingController controller = TextEditingController(
+        text: jsonEncode(
+            TuringMachineModel.fromMachine(machine: widget.machine).toJson()));
+    Logger().w("The Json string is: ${controller.text}");
+    showModalBottomSheet(
+        useSafeArea: true,
+        isScrollControlled: true,
+        context: context,
+        isDismissible: true,
+        enableDrag: false,
+        builder: (context) {
+          return Padding(
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).viewInsets.bottom,
+            ),
+            child: Container(
+              height: 250,
+              padding: const EdgeInsets.only(
+                  bottom: 8.0, top: 15, left: 15, right: 15),
+              child: Center(
+                child: Column(
+                  children: [
+                    const Text(
+                      "Machine Export String to Copy: ",
+                      style:
+                          TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                    const Gap(20),
+                    TextField(
+                      readOnly: true,
+                      controller: controller,
+                      maxLines: 5,
                     ),
                   ],
                 ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,13 +364,21 @@ packages:
     source: hosted
     version: "0.7.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.8.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -411,14 +411,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  logger:
-    dependency: "direct main"
-    description:
-      name: logger
-      sha256: "8c94b8c219e7e50194efc8771cd0e9f10807d8d3e219af473d89b06cc2ee4e04"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   hive_generator: ^2.0.1
+  json_annotation: ^4.9.0
 
 flutter_launcher_icons:
   android: "launcher_icon"
@@ -73,6 +74,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^3.0.0
   build_runner: ^2.4.9
+  json_serializable: ^6.8.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,6 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   google_fonts: ^6.2.1
-  logger: ^2.2.0
   gap: ^3.0.1
   flutter_launcher_icons: ^0.13.1
   hive: ^2.2.3


### PR DESCRIPTION
### Description:

- Add a new feature which allows users to export Turing Machines as an encoded JSON string, and import machines from said 
  encoded JSON strings.
- The feature can be accessed from the 'Load Machine Screen' and the 'Table Screen'.
- The top-right corner in the 'Table Screen' has an Icon Button with a 'share' icon. Clicking this button presents the user with an encoded JSON string representing the machine. This should be copied.
- The top-right corner in the 'Load Machine Screen' has an Icon Button with a 'import/export' icon. Clicking this button presents the user with an input dialog where they must enter an encoded JSON string which they copied after clicking the share button.
- This allows users to share machines across various devices, whilst not interfering with the saved machines.
- Removed logging statements and some comments.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas